### PR TITLE
Fix up the options page

### DIFF
--- a/options.html
+++ b/options.html
@@ -25,7 +25,10 @@
 				<input type="checkbox" id="jsTreeTheme-Dots">
 				Show Dots
 			</div>
-		
+			<div>
+				<input type="checkbox" id="hideApps">
+				Hide apps dock
+			</div>
 		</div>
 		
 		<a href="about.html">About</a>

--- a/options.html
+++ b/options.html
@@ -1,5 +1,5 @@
 <html>
-	<html>
+	<head>
 		
 		<title>Bookmarks New Tab - Options</title>
 		
@@ -7,29 +7,28 @@
 		
 		<script src="libs/jquery.min.js"></script>
 		<script src="libs/jquery-ui.min.js"></script>
-		
+		<script src="options.js"></script>
 	</head>
 	<body>
 		<div class="optionsContainer">
 			<h2>Options</h2>
 			
-			JsTree Theme:
-			<select id="jsTreeTheme-Menu" style="width: 200px;" onchange="localStorage.jsTree_theme = $(this).val();">
-				<option>default</option>
-				<option>classic</option>
-				<option>apple</option>
-			</select>
-			Show Dots:
-			<input type="checkbox" id="jsTreeTheme-Dots" onchange="localStorage.jsTree_themeDots = $(this).val();">
+			<div>
+				JsTree Theme:
+				<select id="jsTreeTheme-Menu" style="width: 200px;">
+					<option>default</option>
+					<option>classic</option>
+					<option>apple</option>
+				</select>
+			</div>
+			<div>
+				<input type="checkbox" id="jsTreeTheme-Dots">
+				Show Dots
+			</div>
 		
 		</div>
 		
 		<a href="about.html">About</a>
-		
-		<script>
-			$("#jsTreeTheme-Menu").val(localStorage.jsTree_theme);
-			$("#jsTreeTheme-Dots").val(localStorage.jsTree_themeDots);
-		</script>
 	</body>
 </html>
 

--- a/options.js
+++ b/options.js
@@ -1,0 +1,21 @@
+
+function parseBool(str)
+{
+	return str==true || str=="true";
+}
+
+function initOptionsPage()
+{
+	$("#jsTreeTheme-Menu").val(localStorage.jsTree_theme);
+	$("#jsTreeTheme-Dots")[0].checked = parseBool(localStorage.jsTree_themeDots);
+
+	$("#jsTreeTheme-Menu").change(function(ev) {
+		localStorage.jsTree_theme = $(ev.target).val();
+	});
+	$("#jsTreeTheme-Dots").change(ev => {
+		localStorage.jsTree_themeDots = $(ev.target)[0].checked;
+	});
+}
+
+$(document).ready(initOptionsPage);
+

--- a/options.js
+++ b/options.js
@@ -8,12 +8,16 @@ function initOptionsPage()
 {
 	$("#jsTreeTheme-Menu").val(localStorage.jsTree_theme);
 	$("#jsTreeTheme-Dots")[0].checked = parseBool(localStorage.jsTree_themeDots);
+	$("#hideApps")[0].checked = parseBool(localStorage.hideApps);
 
 	$("#jsTreeTheme-Menu").change(function(ev) {
 		localStorage.jsTree_theme = $(ev.target).val();
 	});
 	$("#jsTreeTheme-Dots").change(ev => {
 		localStorage.jsTree_themeDots = $(ev.target)[0].checked;
+	});
+	$("#hideApps").change(ev => {
+		localStorage.hideApps = $(ev.target)[0].checked;
 	});
 }
 

--- a/print_apps.js
+++ b/print_apps.js
@@ -12,8 +12,13 @@ function initApps()
 
 function printApps()
 {
-	$('body div.dock-container').empty();
+	if (localStorage.hideApps == "true") {
+		$('body div.dock-container').remove();
+		return;
+	}
 	
+	$('body div.dock-container').empty();
+
 	// Add other menu items.
 	/*
 	var AboutItem = {

--- a/style.css
+++ b/style.css
@@ -102,3 +102,7 @@ li.logo {
 	border-radius: 5px 5px 5px 5px;
 	box-shadow: #577AA2 0 0 10px;
 }
+
+.optionsContainer {
+	margin-top: 20px;
+}

--- a/style.css
+++ b/style.css
@@ -45,6 +45,7 @@ div.other-bookmarks {
 	padding-bottom: 80px;
 }
 .dock-container {
+	display: none;
 	position: absolute;
 	height: 50px;
 	padding-left: 20px;


### PR DESCRIPTION
I don't know whether you're still interested in this extension (I see the last change was in 2012), but it matched what I was looking for, so I forked and fixed it up for my own use.

This PR makes the options page mostly work; it had been broken by a Chrome Content Security Policy change some time after the last release, which blocked inline scripts by default. The options now persist properly (although the jsTree theme still seems to not be applied) I also added an option to hide the app dock (since I myself don't use Chrome apps that way).